### PR TITLE
Respect TTL Expiration on React Native

### DIFF
--- a/API.md
+++ b/API.md
@@ -108,7 +108,7 @@ You can use `createDataLoaderMiddleware(loaders, args)` to add extra objects to 
 
 `options` provides following optional values:
 
-1. `ttl`: Provides a value in millisecond to cache the loader in order to prevent duplicated requests. (_default: 10000_)
+1. `ttl`: Provides a value in millisecond to cache the loader in order to prevent duplicated requests. (_default: 10000_, n/a to server side applications)
 2. `retryTimes`: Total try times when fetching failed. (_default: 1_)
 3. `retryWait`: Wait stategy that sleeps before retrying: (_default: fixedWait(0)_), see [wait-strategies.js](/src/wait-strategies.js) for detail.
 

--- a/src/createDataLoaderMiddleware.js
+++ b/src/createDataLoaderMiddleware.js
@@ -68,7 +68,7 @@ export default function createDataLoaderMiddleware(
         if (Number.isInteger(options.ttl) && options.ttl > 0) {
           const key = uniqueId(`${action.type}__`);
           middleware.runningTasks[key] = { action, promise: runningTask };
-          if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+          if (typeof navigator !== 'undefined') {
             setTimeout(() => {
               delete middleware.runningTasks[key];
             }, options.ttl);


### PR DESCRIPTION
### Problem
Currently the 'ttl' is respected only on web when both `window` and `document` are defined as there is (likely) no need to timeout in a server side application where the redux store is short lived.  On react-native this implementation prevents the tll from ever expiring as neither `window` nor `document` are defined.  The result is that identical load actions are not executed even after the ttl has expired.

### Soultion
Both web and react-native have the global `navigator` defined, whereas server side node applications do not:
  - web: https://www.w3schools.com/jsref/obj_navigator.asp
  - react-native: https://github.com/facebook/react-native/commit/3c65e62183ce05893be0822da217cb803b121c61

By changing the check to `typeof navigator !== 'undefined'` existing behavior is preserved on web and now supports react-native.